### PR TITLE
fixed multiple warnings and fixed a typo. everything static

### DIFF
--- a/src/LoRaWan.cpp
+++ b/src/LoRaWan.cpp
@@ -243,8 +243,8 @@ bool LoRaWanClass::transferPacket(char *buffer, unsigned char timeout)
     for(unsigned char i = 0; i < length; i ++)SerialLoRa.write(buffer[i]);
     sendCommand("\"\r\n");
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif    
@@ -254,7 +254,7 @@ bool LoRaWanClass::transferPacket(char *buffer, unsigned char timeout)
 
 bool LoRaWanClass::transferPacket(unsigned char *buffer, unsigned char length, unsigned char timeout)
 {
-    char temp[2] = {0};
+  char temp[3] = {0};
     
     while(SerialLoRa.available())SerialLoRa.read();
     
@@ -266,8 +266,8 @@ bool LoRaWanClass::transferPacket(unsigned char *buffer, unsigned char length, u
     }
     sendCommand("\"\r\n");
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif    
@@ -285,8 +285,8 @@ bool LoRaWanClass::transferPacketWithConfirmed(char *buffer, unsigned char timeo
     for(unsigned char i = 0; i < length; i ++)SerialLoRa.write(buffer[i]);
     sendCommand("\"\r\n");
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif      
@@ -296,7 +296,7 @@ bool LoRaWanClass::transferPacketWithConfirmed(char *buffer, unsigned char timeo
 
 bool LoRaWanClass::transferPacketWithConfirmed(unsigned char *buffer, unsigned char length, unsigned char timeout)
 {
-    char temp[2] = {0};
+  char temp[3] = {0};
     
     while(SerialLoRa.available())SerialLoRa.read();
     
@@ -310,8 +310,8 @@ bool LoRaWanClass::transferPacketWithConfirmed(unsigned char *buffer, unsigned c
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif      
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
     
     if(strstr(_buffer, "+CMSGHEX: ACK Received"))return true;
     return false;
@@ -323,7 +323,7 @@ short LoRaWanClass::receivePacket(char *buffer, short length, short *rssi)
     short number = 0;
     
     ptr = strstr(_buffer, "RSSI ");
-    if(ptr)*rssi = atoi(ptr + 5);
+  if(ptr)*rssi = (short) strtol(ptr + 5, nullptr, 10);
     else *rssi = -255;
     
     ptr = strstr(_buffer, "RX: \"");
@@ -331,19 +331,20 @@ short LoRaWanClass::receivePacket(char *buffer, short length, short *rssi)
     {        
         ptr += 5;
         
-        uint8_t bitStep = 0;
+      uint8_t bitStep;
         if(*(ptr + 2) == ' ')bitStep = 3; // Firmware version 2.0.10
         else bitStep = 2;                   // Firmware version 2.1.15
         
         for(short i = 0; ; i ++)
         {
             char temp[2] = {0};
-            unsigned char tmp, result = 0;
+          unsigned char tmp = 0;
+          unsigned char result = 0;
             
             temp[0] = *(ptr + i * bitStep);
             temp[1] = *(ptr + i * bitStep + 1);
            
-            for(unsigned char j = 0; j < 2; j ++)
+          for(unsigned char j : temp)
             {
                 if((temp[j] >= '0') && (temp[j] <= '9'))
                 tmp = temp[j] - '0';
@@ -359,13 +360,13 @@ short LoRaWanClass::receivePacket(char *buffer, short length, short *rssi)
 
             if(*(ptr + (i + 1) * bitStep) == '\"' && *(ptr + (i + 1) * bitStep + 1) == '\r' && *(ptr + (i + 1) * bitStep + 2) == '\n')
             {
-                number = i + 1;
+              number = ++i;
                 break;
             }
         }        
     }
        
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
     
     return number;
 }
@@ -380,8 +381,8 @@ bool LoRaWanClass::transferProprietaryPacket(char *buffer, unsigned char timeout
     for(unsigned char i = 0; i < length; i ++)SerialLoRa.write(buffer[i]);
     sendCommand("\"\r\n");
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif    
@@ -391,7 +392,7 @@ bool LoRaWanClass::transferProprietaryPacket(char *buffer, unsigned char timeout
 
 bool LoRaWanClass::transferProprietaryPacket(unsigned char *buffer, unsigned char length, unsigned char timeout)
 {
-    char temp[2] = {0};
+  char temp[3] = {0};
     
     while(SerialLoRa.available())SerialLoRa.read();
     
@@ -403,8 +404,8 @@ bool LoRaWanClass::transferProprietaryPacket(unsigned char *buffer, unsigned cha
     }
     sendCommand("\"\r\n");
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif    
@@ -562,8 +563,8 @@ bool LoRaWanClass::setOTAAJoin(_otaa_join_cmd_t command, unsigned char timeout)
 #endif
     delay(DEFAULT_TIMEWAIT);
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
     SerialUSB.print(_buffer);
 #endif  
@@ -594,7 +595,7 @@ void LoRaWanClass::setDeviceReset(void)
     delay(DEFAULT_TIMEWAIT);
 }
 
-void LoRaWanClass::setDeviceDefault(void)
+void LoRaWanClass::setDeviceDefault()
 {
     sendCommand("AT+FDEFAULT=RISINGHF\r\n");
 #if _DEBUG_SERIAL_
@@ -617,7 +618,7 @@ void LoRaWanClass::initP2PMode(unsigned short frequency, _spreading_factor_t spr
     delay(DEFAULT_TIMEWAIT);
 }
 
-bool LoRaWanClass::transferPacketP2PMode(char *buffer, unsigned char timeout)
+bool LoRaWanClass::transferPacketP2PMode(const char *buffer, unsigned char timeout)
 {
     unsigned char length = strlen(buffer);
     
@@ -634,9 +635,9 @@ bool LoRaWanClass::transferPacketP2PMode(char *buffer, unsigned char timeout)
     return waitForResponse("+TEST: TX DONE", timeout);
 }
 
-bool LoRaWanClass::transferPacketP2PMode(unsigned char *buffer, unsigned char length, unsigned char timeout)
+bool LoRaWanClass::transferPacketP2PMode(const unsigned char *buffer, unsigned char length, unsigned char timeout)
 {
-    char temp[2] = {0};
+  char temp[3] = {0};
     
     sendCommand("AT+TEST=TXLRPKT,\"");
     for(unsigned char i = 0; i < length; i ++)
@@ -663,17 +664,17 @@ short LoRaWanClass::receivePacketP2PMode(unsigned char *buffer, short length, sh
     sendCommandAndWaitForResponse("AT+TEST=RXLRPKT\r\n", "+TEST: RXLRPKT", 2);
     
     while(SerialLoRa.available())SerialLoRa.read();
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
-    readBuffer(_buffer, BEFFER_LENGTH_MAX, timeout);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
+  readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
     
     ptr = strstr(_buffer, "LEN");
-    if(ptr)number = atoi(ptr + 4);
+  if(ptr) number = (short) strtol(ptr + 4, nullptr, 10);
     else number = 0;
     
     if(number <= 0)return 0;
     
     ptr = strstr(_buffer, "RSSI:");
-    if(ptr)*rssi = atoi(ptr + 5);
+  if(ptr)*rssi = (short) strtol(ptr + 5, nullptr, 10);
     else *rssi = -255;
     
     ptr = strstr(_buffer, "RX \"");
@@ -688,12 +689,13 @@ short LoRaWanClass::receivePacketP2PMode(unsigned char *buffer, short length, sh
         for(short i = 0; i < number; i ++)
         {
             char temp[2] = {0};
-            unsigned char tmp, result = 0;
+          unsigned char tmp = 0;
+          unsigned char result = 0;
             
             temp[0] = *(ptr + i * bitStep);
             temp[1] = *(ptr + i * bitStep + 1);
            
-            for(unsigned char j = 0; j < 2; j ++)
+          for(unsigned char j : temp)
             {
                 if((temp[j] >= '0') && (temp[j] <= '9'))
                 tmp = temp[j] - '0';
@@ -709,14 +711,14 @@ short LoRaWanClass::receivePacketP2PMode(unsigned char *buffer, short length, sh
         }
     }
     
-    memset(_buffer, 0, BEFFER_LENGTH_MAX);
+  memset(_buffer, 0, BUFFER_LENGTH_MAX);
     
     return number;
 }
 
-short LoRaWanClass::getBatteryVoltage(void)
+short LoRaWanClass::getBatteryVoltage()
 {
-    int battery;
+  uint32_t battery;
     
     pinMode(CHARGE_STATUS_PIN, OUTPUT);
     digitalWrite(CHARGE_STATUS_PIN, LOW);
@@ -724,7 +726,7 @@ short LoRaWanClass::getBatteryVoltage(void)
     battery = (analogRead(BATTERY_POWER_PIN) * 3300 * 11) >> 10;
     pinMode(CHARGE_STATUS_PIN, INPUT);
     
-    return battery;
+  return (short)(battery);
 }
 
 void LoRaWanClass::loraDebug(void)
@@ -740,7 +742,7 @@ void LoRaWanClass::loraDebugPrint(unsigned char timeout)
 
     timerStart = millis();
     
-    while(1)
+  while(true)
     {
         while(SerialLoRa.available()) SerialUSB.write(SerialLoRa.read());  
         
@@ -750,7 +752,7 @@ void LoRaWanClass::loraDebugPrint(unsigned char timeout)
 }
 #endif
 
-void LoRaWanClass::sendCommand(char *command)
+void LoRaWanClass::sendCommand(const char *command)
 {
     SerialLoRa.print(command);
 }
@@ -762,7 +764,7 @@ short LoRaWanClass::readBuffer(char *buffer, short length, unsigned char timeout
 
     timerStart = millis();
 
-    while(1)
+  while(true)
     {
         if(i < length)
         {
@@ -780,21 +782,21 @@ short LoRaWanClass::readBuffer(char *buffer, short length, unsigned char timeout
     return i;
 }
 
-bool LoRaWanClass::waitForResponse(char* response, unsigned char timeout)
+bool LoRaWanClass::waitForResponse(const char *response, unsigned char timeout)
 {
-    short len = strlen(response);
+  auto len = (short)(strlen(response));
     short sum = 0;
-    unsigned long timerStart,timerEnd;
+    unsigned long timerStart, timerEnd;
     
     timerStart = millis();
 
-    while(1)
+  while(true)
     {
         if(SerialLoRa.available())
         {
             char c = SerialLoRa.read();
 
-            sum = (c == response[sum]) ? sum + 1 : 0;
+            c == response[sum] ? sum++ : sum = 0;
             if(sum == len)break;
         }
         
@@ -805,12 +807,12 @@ bool LoRaWanClass::waitForResponse(char* response, unsigned char timeout)
     return true;
 }
 
-bool LoRaWanClass::sendCommandAndWaitForResponse(char* command, char *response, unsigned char timeout)
+bool LoRaWanClass::sendCommandAndWaitForResponse(const char *command, const char *response, unsigned char timeout)
 {
     sendCommand(command);
     
     return waitForResponse(response, timeout);
 }
 
-
 LoRaWanClass lora;
+char LoRaWanClass::_buffer[BUFFER_LENGTH_MAX] = {0};

--- a/src/LoRaWan.cpp
+++ b/src/LoRaWan.cpp
@@ -246,7 +246,7 @@ bool LoRaWanClass::transferPacket(char *buffer, unsigned char timeout)
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif    
     if(strstr(_buffer, "+MSG: Done"))return true;
     return false;
@@ -269,7 +269,7 @@ bool LoRaWanClass::transferPacket(unsigned char *buffer, unsigned char length, u
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif    
     if(strstr(_buffer, "+MSGHEX: Done"))return true;
     return false;
@@ -288,7 +288,7 @@ bool LoRaWanClass::transferPacketWithConfirmed(char *buffer, unsigned char timeo
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif      
     if(strstr(_buffer, "+CMSG: ACK Received"))return true;
     return false;
@@ -308,7 +308,7 @@ bool LoRaWanClass::transferPacketWithConfirmed(unsigned char *buffer, unsigned c
     }
     sendCommand("\"\r\n");
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif      
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
@@ -384,7 +384,7 @@ bool LoRaWanClass::transferProprietaryPacket(char *buffer, unsigned char timeout
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif    
     if(strstr(_buffer, "+PMSG: Done"))return true;
     return false;
@@ -407,7 +407,7 @@ bool LoRaWanClass::transferProprietaryPacket(unsigned char *buffer, unsigned cha
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif    
     if(strstr(_buffer, "+PMSGHEX: Done"))return true;
     return false;
@@ -566,7 +566,7 @@ bool LoRaWanClass::setOTAAJoin(_otaa_join_cmd_t command, unsigned char timeout)
   memset(_buffer, 0, BUFFER_LENGTH_MAX);
   readBuffer(_buffer, BUFFER_LENGTH_MAX, timeout);
 #if _DEBUG_SERIAL_    
-    SerialUSB.print(_buffer);
+    SerialDebug.print(_buffer);
 #endif  
 
     ptr = strstr(_buffer, "+JOIN: Join failed");
@@ -731,8 +731,8 @@ short LoRaWanClass::getBatteryVoltage()
 
 void LoRaWanClass::loraDebug(void)
 {
-    if(SerialUSB.available())SerialLoRa.write(SerialUSB.read());
-    if(SerialLoRa.available())SerialUSB.write(SerialLoRa.read());
+    if(SerialDebug.available())SerialLoRa.write(SerialDebug.read());
+    if(SerialLoRa.available())SerialDebug.write(SerialLoRa.read());
 }
 
 #if _DEBUG_SERIAL_
@@ -744,7 +744,7 @@ void LoRaWanClass::loraDebugPrint(unsigned char timeout)
     
   while(true)
     {
-        while(SerialLoRa.available()) SerialUSB.write(SerialLoRa.read());  
+        while(SerialLoRa.available()) SerialDebug.write(SerialLoRa.read());  
         
         timerEnd = millis();
         if(timerEnd - timerStart > 1000 * timeout)break;

--- a/src/LoRaWan.h
+++ b/src/LoRaWan.h
@@ -45,7 +45,7 @@
 #define BATTERY_POWER_PIN    A4
 #define CHARGE_STATUS_PIN    A5
 
-#define BEFFER_LENGTH_MAX    256
+#define BUFFER_LENGTH_MAX    256
 
 
 enum _class_type_t { CLASS_A = 0, CLASS_C };
@@ -109,7 +109,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void init(void);
+        static void init(void);
         
         /**
          *  \brief Read the version from device
@@ -120,7 +120,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void getVersion(char *buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static void getVersion(char *buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
         
         /**
          *  \brief Read the ID from device
@@ -131,7 +131,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void getId(char *buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static void getId(char *buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
 
         /**
          *  \brief Set the ID
@@ -142,7 +142,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setId(char *DevAddr, char *DevEUI, char *AppEUI);
+        static void setId(char *DevAddr, char *DevEUI, char *AppEUI);
         
         /**
          *  \brief Set the key
@@ -153,7 +153,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setKey(char *NwkSKey, char *AppSKey, char *AppKey);
+        static void setKey(char *NwkSKey, char *AppSKey, char *AppKey);
         
         /**
          *  \brief Set the data rate
@@ -163,7 +163,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */        
-        void setDataRate(_data_rate_t dataRate = DR0, _physical_type_t physicalType = EU434); 
+        static void setDataRate(_data_rate_t dataRate = DR0, _physical_type_t physicalType = EU434);
         
         /**
          *  \brief ON/OFF adaptive data rate mode
@@ -172,7 +172,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */ 
-        void setAdaptiveDataRate(bool command);
+        static void setAdaptiveDataRate(bool command);
         
         /**
          *  \brief Set the output power
@@ -181,7 +181,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setPower(short power);
+        static void setPower(short power);
         
         /**
          *  \brief Set the port number
@@ -190,7 +190,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setPort(unsigned char port);
+        static void setPort(unsigned char port);
         
         /**
          *  \brief Set the channel parameter
@@ -200,7 +200,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setChannel(unsigned char channel, float frequency);
+        static void setChannel(unsigned char channel, float frequency);
         /**
          *  \brief Set the channel parameter
          *  
@@ -210,7 +210,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setChannel(unsigned char channel, float frequency, _data_rate_t dataRata);
+        static void setChannel(unsigned char channel, float frequency, _data_rate_t dataRata);
         /**
          *  \brief Set the channel parameter
          *  
@@ -221,7 +221,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        void setChannel(unsigned char channel, float frequency, _data_rate_t dataRataMin, _data_rate_t dataRataMax);
+        static void setChannel(unsigned char channel, float frequency, _data_rate_t dataRataMin, _data_rate_t dataRataMax);
         
         /**
          *  \brief Transfer the data
@@ -231,7 +231,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        bool transferPacket(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferPacket(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the data
          *  
@@ -241,7 +241,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        bool transferPacket(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferPacket(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the packet data
          *  
@@ -250,7 +250,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : Confirmed ACK, false : Confirmed NOT ACK
          */
-        bool transferPacketWithConfirmed(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferPacketWithConfirmed(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the data
          *  
@@ -260,7 +260,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : Confirmed ACK, false : Confirmed NOT ACK
          */
-        bool transferPacketWithConfirmed(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferPacketWithConfirmed(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
 
         /**
          *  \brief Receive the data
@@ -271,7 +271,7 @@ class LoRaWanClass
          *  
          *  \return Return Receive data number
          */
-        short receivePacket(char *buffer, short length, short *rssi);
+        static short receivePacket(char *buffer, short length, short *rssi);
         
         /**
          *  \brief Transfer the proprietary data
@@ -281,7 +281,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        bool transferProprietaryPacket(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferProprietaryPacket(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the proprietary data
          *  
@@ -291,7 +291,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        bool transferProprietaryPacket(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferProprietaryPacket(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
         
         /**
          *  \brief Set device mode
@@ -300,7 +300,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setDeciveMode(_device_mode_t mode);
+        static void setDeciveMode(_device_mode_t mode);
         
         /**
          *  \brief Set device join a network
@@ -310,7 +310,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. True : join OK, false : join NOT OK
          */
-        bool setOTAAJoin(_otaa_join_cmd_t command, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool setOTAAJoin(_otaa_join_cmd_t command, unsigned char timeout = DEFAULT_TIMEOUT);
         
         /**
          *  \brief Set message unconfirmed repeat time
@@ -319,7 +319,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setUnconfirmedMessageRepeatTime(unsigned char time);
+        static void setUnconfirmedMessageRepeatTime(unsigned char time);
         
         /**
          *  \brief Set message retry times time
@@ -328,7 +328,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setConfirmedMessageRetryTime(unsigned char time);
+        static void setConfirmedMessageRetryTime(unsigned char time);
         
         /**
          *  \brief ON/OFF receice window 1
@@ -337,7 +337,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setReceiceWindowFirst(bool command);
+        static void setReceiceWindowFirst(bool command);
         /**
          *  \brief Set receice window 1 channel mapping
          *  
@@ -346,7 +346,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setReceiceWindowFirst(unsigned char channel, float frequency);
+        static void setReceiceWindowFirst(unsigned char channel, float frequency);
         
         /**
          *  \brief Set receice window 2 channel mapping
@@ -356,7 +356,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setReceiceWindowSecond(float frequency, _data_rate_t dataRate);
+        static void setReceiceWindowSecond(float frequency, _data_rate_t dataRate);
         
         /**
          *  \brief Set receice window 2 channel mapping
@@ -367,7 +367,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setReceiceWindowSecond(float frequency, _spreading_factor_t spreadingFactor, _band_width_t bandwidth);
+        static void setReceiceWindowSecond(float frequency, _spreading_factor_t spreadingFactor, _band_width_t bandwidth);
         
         /**
          *  \brief ON/OFF duty cycle limitation
@@ -376,7 +376,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setDutyCycle(bool command);
+        static void setDutyCycle(bool command);
         
         /**
          *  \brief ON/OFF join duty cycle limitation
@@ -385,7 +385,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setJoinDutyCycle(bool command);
+        static void setJoinDutyCycle(bool command);
         
         /**
          *  \brief Set receice window delay
@@ -395,7 +395,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setReceiceWindowDelay(_window_delay_t command, unsigned short _delay);
+        static void setReceiceWindowDelay(_window_delay_t command, unsigned short _delay);
         
         /**
          *  \brief Set LoRaWAN class type
@@ -404,28 +404,28 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void setClassType(_class_type_t type);
+        static void setClassType(_class_type_t type);
         
         /**
          *  \brief Set device into low power mode
          *  
          *  \return Return null
          */
-        void setDeviceLowPower(void);
+        static void setDeviceLowPower(void);
         
         /**
          *  \brief Reset device
          *  
          *  \return Return null
          */
-        void setDeviceReset(void);
+        static void setDeviceReset(void);
         
         /**
          *  \brief Setup device default
          *  
          *  \return Return null
          */
-        void setDeviceDefault(void);
+        static void setDeviceDefault(void);
         
         /**
          *  \brief Initialize device into P2P mode
@@ -439,7 +439,7 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        void initP2PMode(unsigned short frequency = 433, _spreading_factor_t spreadingFactor = SF12, _band_width_t bandwidth = BW125, 
+        static void initP2PMode(unsigned short frequency = 433, _spreading_factor_t spreadingFactor = SF12, _band_width_t bandwidth = BW125,
                          unsigned char txPreamble = 8, unsigned char rxPreamble = 8, short power = 20); 
         
         /**
@@ -449,7 +449,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        bool transferPacketP2PMode(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT); 
+        static bool transferPacketP2PMode(const char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the data
          *  
@@ -458,7 +458,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        bool transferPacketP2PMode(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool transferPacketP2PMode(const unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Receive the data
          *  
@@ -469,16 +469,16 @@ class LoRaWanClass
          *  
          *  \return Return Receive data number
          */
-        short receivePacketP2PMode(unsigned char *buffer, short length, short *rssi, unsigned char timeout = DEFAULT_TIMEOUT);
+        static short receivePacketP2PMode(unsigned char *buffer, short length, short *rssi, unsigned char timeout = DEFAULT_TIMEOUT);
         
         /**
          *  \brief LoRaWAN raw data
          *  
          *  \return Return null
          */
-        void loraDebug(void);
+        static void loraDebug(void);
 #if _DEBUG_SERIAL_
-        void loraDebugPrint(unsigned char timeout);  
+        static void loraDebugPrint(unsigned char timeout);
 #endif  
 
         /**
@@ -486,16 +486,16 @@ class LoRaWanClass
          *  
          *  \return Return battery voltage
          */
-        short getBatteryVoltage(void);
+        static short getBatteryVoltage(void);
         
         
     private:
-        void sendCommand(char *command);
-        short readBuffer(char* buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
-        bool waitForResponse(char* response, unsigned char timeout = DEFAULT_TIMEOUT);
-        bool sendCommandAndWaitForResponse(char* command, char *response, unsigned char timeout = DEFAULT_TIMEOUT);
+        static void sendCommand(const char *command);
+        static short readBuffer(char* buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool waitForResponse(const char* response, unsigned char timeout = DEFAULT_TIMEOUT);
+        static bool sendCommandAndWaitForResponse(const char* command, const char *response, unsigned char timeout = DEFAULT_TIMEOUT);
+  	static char _buffer[BUFFER_LENGTH_MAX];
         
-        char _buffer[256];
 
 };
 

--- a/src/LoRaWan.h
+++ b/src/LoRaWan.h
@@ -52,6 +52,9 @@
 
 #define BUFFER_LENGTH_MAX    256
 
+enum _packet_type_t{MSG,MSGHEX,PMSG,PMSGHEX,CMSG,CMSGHEX,TXLRSTR,TXLRPKT, _SIZE_OF_PACKET_TYPE};
+//lookup to packet type string
+const char packet_type_lookup[_SIZE_OF_PACKET_TYPE][8] = {"MSG","MSGHEX","PMSG","PMSGHEX","CMSG","CMSGHEX","TXLRSTR","TXLRPKT"};
 
 enum _class_type_t { CLASS_A = 0, CLASS_C };
 enum _physical_type_t { EU434 = 0, EU868, US915, US915HYBRID, AU915, AU915OLD, CN470, CN779, AS923, KR920, IN865 };
@@ -158,7 +161,7 @@ class LoRaWanClass
          *  
          *  \return Return null.
          */
-        static void setKey(char *NwkSKey, char *AppSKey, char *AppKey);
+  static void setKey(const char *NwkSKey,const char *AppSKey,const char *AppKey);
         
         /**
          *  \brief Set the data rate
@@ -228,15 +231,16 @@ class LoRaWanClass
          */
         static void setChannel(unsigned char channel, float frequency, _data_rate_t dataRataMin, _data_rate_t dataRataMax);
         
+  static void enableChannels(unsigned char fistChannel = 0, unsigned char lastChannel = 2);
         /**
          *  \brief Transfer the data
-         *  
+   *  \details this function sends the data inside of a AT+MSG packet
          *  \param [in] *buffer The transfer data cache
          *  \param [in] timeout The over time of transfer
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        static bool transferPacket(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
+  static bool transferPacket(const char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the data
          *  
@@ -246,7 +250,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : transfer done, false : transfer failed
          */
-        static bool transferPacket(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
+  static bool transferPacket(const unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the packet data
          *  
@@ -255,7 +259,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : Confirmed ACK, false : Confirmed NOT ACK
          */
-        static bool transferPacketWithConfirmed(char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
+  static bool transferPacketWithConfirmed(const char *buffer, unsigned char timeout = DEFAULT_TIMEOUT);
         /**
          *  \brief Transfer the data
          *  
@@ -265,7 +269,7 @@ class LoRaWanClass
          *  
          *  \return Return bool. Ture : Confirmed ACK, false : Confirmed NOT ACK
          */
-        static bool transferPacketWithConfirmed(unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
+  static bool transferPacketWithConfirmed(const unsigned char *buffer, unsigned char length, unsigned char timeout = DEFAULT_TIMEOUT);
 
         /**
          *  \brief Receive the data
@@ -418,6 +422,13 @@ class LoRaWanClass
          */
         static void setDeviceLowPower(void);
         
+  /**
+   *  \brief Wake up device
+   *
+   *  \return Return null
+   */
+  static void wakeUp(void);
+
         /**
          *  \brief Reset device
          *  
@@ -444,9 +455,12 @@ class LoRaWanClass
          *  
          *  \return Return null
          */
-        static void initP2PMode(unsigned short frequency = 433, _spreading_factor_t spreadingFactor = SF12, _band_width_t bandwidth = BW125,
+  static void initP2PMode(unsigned short frequency, _spreading_factor_t spreadingFactor = SF12, _band_width_t bandwidth = BW125,
                          unsigned char txPreamble = 8, unsigned char rxPreamble = 8, short power = 20); 
         
+  static void initP2PMode();
+
+
         /**
          *  \brief Transfer the data
          *  
@@ -493,15 +507,17 @@ class LoRaWanClass
          */
         static short getBatteryVoltage(void);
         
+  static bool transferPacketWithType(_packet_type_t packet_type,const char *buffer, unsigned char length = 0, unsigned char timeout = DEFAULT_TIMEOUT);
+
         
     private:
         static void sendCommand(const char *command);
+  static void sendChar(const char command);
         static short readBuffer(char* buffer, short length, unsigned char timeout = DEFAULT_TIMEOUT);
         static bool waitForResponse(const char* response, unsigned char timeout = DEFAULT_TIMEOUT);
         static bool sendCommandAndWaitForResponse(const char* command, const char *response, unsigned char timeout = DEFAULT_TIMEOUT);
   	static char _buffer[BUFFER_LENGTH_MAX];
-        
-
+  static bool inLowPowerMode;
 };
 
 

--- a/src/LoRaWan.h
+++ b/src/LoRaWan.h
@@ -34,8 +34,13 @@
 
 #include <Arduino.h>
 
-
+#ifndef SerialLoRa
 #define SerialLoRa          Serial1
+#endif
+
+#ifndef SerialDebug
+#define SerialDebug         SerialUSB
+#endif
 
 #define _DEBUG_SERIAL_      1
 #define DEFAULT_TIMEOUT     5 // second


### PR DESCRIPTION
fixed the following warnings,

ISO C++11 does not allow conversion from string literal to 'char *'. 
this happened becuase char * was used and not const char * for string literals.

also fixed the typo of BEFFER_LENGTH_MAX to BUFFER_LENGTH_MAX

also replaced atoi calls with more safer strtol.
made the whole class static, because there can only be one.